### PR TITLE
fixes to more reliably build libyaml

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -17,17 +17,17 @@ my $builder = Alien::Base::ModuleBuild->new(
     alien_name => 'libyaml',
     alien_repository => {
         protocol => 'http',
-        host     => 'bitbucket.org',
-        location => '/xi/libyaml/get/',
-        exact_filename => '0.1.6.tar.gz',
-        exact_version => '0.1.6'
+        host     => 'pyyaml.org/',
+        location => '/download/libyaml/',
+        pattern  => qr{^yaml-.*\.tar\.gz$},
     },
     alien_build_commands => [
-        '%pbootstrap',
-        '%pconfigure --prefix=%s --enable-shared',
-        'make',
-        'make install'
+      'patch -p1 < ../../yaml-0.1.6.patch',
+      '%c --prefix=%s',
+      'make',
+      'make install',
     ],
+    alien_isolate_dynamic => 1,
     # Prerequisites inserted by DistZilla:
     ##{ $plugin->get_prereqs ##}
 );

--- a/dist.ini
+++ b/dist.ini
@@ -31,7 +31,7 @@ bugtracker.github = user:rsimoes
 skip = ^(?:base|strict|warnings|if|utf8|charnames|open|parent|re|subs|version|Carp|File::Spec::Functions|List::Util|POSIX|Params::Check|Scalar::Util)$
 
 [Prereqs / ConfigureRequires]
-Alien::Base::ModuleBuild = 0.004
+Alien::Base::ModuleBuild = 0.005
 
 [PruneFiles]
 filename=dist.ini

--- a/yaml-0.1.6.patch
+++ b/yaml-0.1.6.patch
@@ -1,0 +1,10 @@
+diff -u -r yaml-0.1.6/yaml-0.1.pc.in yaml-0.1.6.o/yaml-0.1.pc.in
+--- yaml-0.1.6/yaml-0.1.pc.in	2014-09-24 15:20:01.564362299 -0400
++++ yaml-0.1.6.o/yaml-0.1.pc.in	2014-03-26 14:54:02.000000000 -0400
+@@ -6,5 +6,5 @@
+ Name: LibYAML
+ Description: Library to parse and emit YAML
+ Version: @PACKAGE_VERSION@
++Cflags: -I${includedir}
+-Cflags:
+ Libs: -L${libdir} -lyaml


### PR DESCRIPTION
I think these changes will make Alien::LibYAML install more reliably from CPAN:
- build from a tar that already has a working configure
- use Alien::Base 0.005 %c to get --with-pic
- use Alien::Base 0.005 alien_isolate_dynamic so that XS modules can link against static libs
- patch the .pc file so that an appropriate -I flag is provided

Some of this depends on new features and bug fixes that we included in AB 0.005.  If you have any questions or concerns about this approach please let me know.  I am one of the core AB developers.

Thanks!
