### PR TITLE
support for Perl 5.8

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-use v5.10;
 use strict;
 use warnings FATAL => 'all';
 use utf8;

--- a/lib/Alien/LibYAML.pm
+++ b/lib/Alien/LibYAML.pm
@@ -1,6 +1,5 @@
 package Alien::LibYAML;
 
-use v5.10;
 use strict;
 use warnings FATAL => 'all';
 use utf8;

--- a/t/01-methods.t
+++ b/t/01-methods.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-use v5.10;
 use strict;
 use warnings FATAL => "all";
 use Alien::LibYAML;


### PR DESCRIPTION
I sympathize with your position on Perl 5.8 support (#4).  However,
- requiring 5.10 for this module is arbitrary since it doesn't use any 5.10 features
- most people still on 5.8 are not there out of choice, and requiring 5.10 is likely to make them simply not use `Alien::LibYAML` rather than to make them upgrade their Perl (I was there rather recently in fact)
- most issues are going to be in AB rather than `Alien::LibYAML`, any issues raised will most likely be our responsibility
- issues that _are_ raised, help us shake out bugs in AB itself
- the AB team is committed to support 5.8 as long as the other parts of the tool chain do

I understand and respect your decision if you decide not to merge this PR.
